### PR TITLE
use default x86_64 for arg, as 32bit support is discouraged in Arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bootstrap*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM scratch
 MAINTAINER Maciej Sieczka
 
 # Set the $architecture ARG on your `docker build' command line with `--build-arg architecture=x86_64' or `i686'.
-ARG architecture
+ARG architecture=x86_64
 
 ADD bootstrap.tar.gz /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Maciej Sieczka
 # Set the $architecture ARG on your `docker build' command line with `--build-arg architecture=x86_64' or `i686'.
 ARG architecture=x86_64
 
-ADD bootstrap.tar.gz /
+ADD bootstrap-${architecture}.tar.gz /
 
 RUN if [ "$architecture" != "x86_64" -a "$architecture" != "i686" ]; then \
     printf '\nYou need to specify the architecture with "--build-arg architecture=i686" on your\n\

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ It's meant to provide an easy to use solution for building Arch Linux Docker ima
 
 - Download an <code>archlinux-bootstrap-<i>date-architecture</i>.tar.gz</code> archive, preferably the newest one (or expect a longer `pacman -Syu` run at `docker build`). From my experience, https://archive.archlinux.org/iso/ is a very fast mirror, but you may want to choose your preferred one on https://www.archlinux.org/download/.
 
-- Run <code>tar_fix.py --input=archlinux-bootstrap-<i>date-architecture</i>.tar.gz --output=bootstrap.tar.gz</code>. This will remove input tarball's top-level directory from all its component paths, and save that in the output tarball. As a result its content starts at `/` rather than `x86_64/` or `i686/`, and so will the filesystem of the Docker image.
+- Run <code>tar_fix.py --input=archlinux-bootstrap-<i>date-architecture</i>.tar.gz --output=bootstrap-<i>architecture</i>.tar.gz</code>. This will remove input tarball's top-level directory from all its component paths, and save that in the output tarball. As a result its content starts at `/` rather than `x86_64/` or `i686/`, and so will the filesystem of the Docker image.
 
-- Place this `Dockerfile`, its `.dockerignore` and the `bootstrap.tar.gz` in one directory.
+- `docker build --tag archlinux-<i>architecture</i>-base .` **Mind the dot!**
 
-- `cd` to that directory and build the image with a command like `docker build --build-arg architecture=x86_64 --tag archlinux-x86_64-base .`. Mind the dot! Use `--build-arg architecture=i686` if you are building from an i686 `bootstrap.tar.gz`.
+Use `--build-arg architecture=i686` if you are building from an i686 `bootstrap.tar.gz`.
 
 ###See also
 


### PR DESCRIPTION
i686 is not heavily used anymore, it might be a sane option to add x86_64 as the default in the Dockerfile.

See here: https://pierre-schmitz.com/farewell-i686/
> The question is not if 32 bit support might be dropped, but when.

Or: https://www.archlinux.de/?page=PackageStatistics